### PR TITLE
remove – from release year value if present

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -43,7 +43,7 @@ function createTemplate(movies) {
         <div class="movie-container">
           <img src="${movie.Poster}" alt="${movie.Title}"/>
           <h5 class="movie-title margin-0">${movie.Title}</h5>
-          <p class="margin-0"><span>Release Year:</span> ${movie.Year}</p>
+          <p class="margin-0"><span>Release Year:</span> ${removeHyphen(movie.Year)}</p>
           <p class="margin-0"><span>Type:</span> ${movie.Type}</p>
           <a href="movies.html" class="view-details item-${index}">View Details</a>
         </div>
@@ -60,4 +60,12 @@ function createTemplate(movies) {
 function changeClass(classAdd, classRemove) {
   document.querySelector("#movies").classList.add(classAdd);
   document.querySelector("#movies").classList.remove(classRemove);
+}
+
+function removeHyphen(str) {
+  if(str.charAt(str.length - 1) == "–") {
+    str = str.slice(0, str.length - 1);
+    return str;
+  }
+  return str;
 }


### PR DESCRIPTION
Some of the movie release year contains – at the end(Now Fixed)

Before: 
<img width="1280" alt="screen shot 2017-12-20 at 6 50 04 pm" src="https://user-images.githubusercontent.com/10830363/34267698-cfa59ba8-e6a3-11e7-936a-d35e2be521da.png">
<img width="1280" alt="screen shot 2017-12-20 at 8 23 43 pm" src="https://user-images.githubusercontent.com/10830363/34269370-05cded10-e6aa-11e7-956a-a2a6476daed0.png">

After:
<img width="709" alt="screen shot 2017-12-21 at 11 53 22 pm" src="https://user-images.githubusercontent.com/10830363/34269434-4529dbe0-e6aa-11e7-9fc1-146a2cee531f.png">
<img width="1280" alt="screen shot 2017-12-21 at 11 54 08 pm" src="https://user-images.githubusercontent.com/10830363/34269435-4565f10c-e6aa-11e7-9b0c-a0abe27ed45e.png">

